### PR TITLE
00314 fix dz locations data quality issues

### DIFF
--- a/resources/drop-zones-loc-elev-raw.csv
+++ b/resources/drop-zones-loc-elev-raw.csv
@@ -1,259 +1,252 @@
 elevation,lat,lon,name,country,DZ
-2,36.649092,174.934864,Parakai Auckland,NZL,Skydive Auckland
-238,41.8926,-89.0796,Rochelle,USA,Chicagoland Skydiving Center
-24,29.067,-81.2837,DeLand,USA,Skydive Deland
-386,33.63,-117.3017,Elsinore,USA,Skydive Elsinore
-461,32.8067,-111.5866,Eloy,USA,Skydive Arizona
-416,36.5681,-114.4433,Overton,USA,Skydive Fyrosity
-83,47.2335,-123.1475,Shelton,USA,Skydive Kapowsin
-72,51.6472,7.1633,Marl,GER,Fallschirmsport Marl e.V.
-135,51.2472,-1.7542,Netheravon,GBR,Skydive Netheravon
-8,33.218,-117.3515,Oceanside,USA,GoJump Oceanside
-431,33.7646,-117.219,Perris,USA,Skydive Perris
-0,44.3643,12.2249,Ravenna,ITA,Skydive Pull Out Ravenna
-27,34.6656,-120.4675,Lompoc,USA,Skydive Santa Barbara
-7,27.8132,-80.4955,Sebastian,USA,Skydive Sebastian
-832,45.07929542632054,3.7620959846568214,Chazpuzac,FRA,Paraclub du Puy
-188,41.3997,-88.7939,Ottawa,USA,Skydive Chicago
-240,42.7032,-87.9589,Sturtevant,USA,Skydive Midwest
-15,29.3569,-95.4594,Rosharon,USA,Skydive Spaceland Houston
-27,28.228,-82.156,Zephyrhills,USA,Skydive City Zephyrhills
-140,-36.784904,145.039509,Bailieston,AUS,Skydive Nagambie
-18,38.2024417,-121.2691417,Lodi,USA,Skydive Lodi Parachute Center
-13,37.02865,15.243458,Siracusa,ITA,SkydiveSicilia Siracusa
-127,56.798392,37.3312258,Borki,RUS,DZ Borki
-238,54.789712,37.642467,Pushchino,RUS,DZ Pushchino
-156,46.389969,17.731702,Kaposvar,RUS,Kapos DropZone
-26,44.93794,38.928427,Enem,RUS,DZ Enem
-7,44.597435,11.653231,Molinella,ITA,Moli D Zone
-127,46.86286498,18.08786809,Siofok,HUN,Skydive Balaton
-50,54.6494302,24.06236627,Pociunai,LTU,Kaunas Skydiving Club
-1248,-25.663383,28.220384,Pretoria,RSA,Skydive Pretoria
-144,55.091244,38.918871,Kolomna,RUS,Aerograd Kolomna
-2,42.25945116,3.10997844,Empuriabrava,ESP,Skydive Empuriabrava
-40,53.24922509,50.04617929,Samara,RUS,Sky Roads Samara
-60,58.98742257,24.72462416,Kuusiku,EST,Skydive Estonia
-170,-31.82505824,116.7982829,York,AUS,Skydive York
-331,50.52436163,13.68278503,Most,CZE,
-466,49.719174,14.097512,Pribram,CZE,
-214,49.4478303,17.13403702,Prostejov,CZE,JUMP-TANDEM s.r.o.
-555,49.42058439,15.63575506,Jihlava,CZE,
-190,39.5325855,-89.3307069,Taylorville,USA,Mid-America Sport Parachute
-20,56.31325799,10.6151104,Aarhus,DEN,
-93,35.02100849,-79.18919563,Raeford,USA,Skydive Paraclete XP
-1,53.11766712,4.82857704,Texel,NED,Paracentrum Texel
-5,52.24088496,6.04436338,Teuge,NED,National Paracentrum Teuge
-267,50.00604103,15.17419517,Kolin,CZE,
-40,47.08796908,39.41306591,Azov,RUS,
-160,47.06611354,29.09283757,Vaduleni,MDA,
-149,32.63484506,-116.8917874,San Diego,USA,Skydive San Diego
-19,37.8350433,-121.6329646,Byron,USA,Bay Area Skydiving
-16,43.22684599,13.74195457,Fermo,ITA,
-157,24.88522721,55.54800689,Dubai Desert,UAE,Skydive Dubai Desert
-0,25.09082159,55.13685107,Dubai Palm,UAE,Skydive Dubai Palm
-195,-33.34663973,18.6969173,Cape Town,RSA,
-195,55.66244577,36.13871098,Vatulino,RUS,
-153,61.14644025,25.69403887,Vesivehmaa,FIN,
-254,50.270693,18.67427454,Gliwice,POL,
-103,60.89762139,26.92609549,Utti,FIN,Skydive Finland
-1317,40.61318686,-112.3481226,Tooele,USA,Skydive Utah
-675,54.14057759,-113.7459719,Edmonton,CAN,
-90,55.85087572,13.32844377,Eslov,SWE,
-127,54.27608164,40.81944466,Shilovo,RUS,DZ Krutitcy
-32,60.28506246,17.42562532,Tierp,SWE,Stockholm Fallskärmsklubb
-6,49.09533273,-122.3131299,Abbotsford,CAN,
-96,43.37139838,-70.92569053,Lebanon,USA,Skydive New England
-120,51.58022318,8.21502686,Soest,GER,Skydive Soest
-512,48.23524297,10.13660431,Illertissen ,GER,
-739,47.83980781,10.86618125,Altenstadt,GER,
-140,29.76916902,-97.77274668,San Marcos,USA,Skydive Spaceland San Marcos
-132,38.19478125,-90.38583577,Festus,USA,Fly Free Skydiving
-628,49.46677838,20.04737735,Nowy Targ,POL,Nowy Targ Skydive
-91,60.63985851,6.50203407,Voss,NOR,Skydive Voss
-16,43.82527776,13.03186655,Fano,ITA,Skydive Fano
-199,45.65325073,4.91643548,Lyon,FRA,
-195,-33.81211406,19.90240395,Robertson,RSA,Skydive Robertson
-22,45.63220146,-0.9768793,Royan,FRA,
-1,54.710181,18.64605188,Jastarnia,POL,
-184,46.630755,16.178322,Murska Sobota,SLO,
-45,37.29575614,-6.16133451,Seville,ESP,
-49,45.16766289,10.0071609,Cremona,ITA,
-305,44.83440972,7.36347914,Garzigliana,ITA,
+2.0,36.649092,174.934864,Parakai Auckland,NZL,Skydive Auckland
+238.0,41.8926,-89.0796,Rochelle,USA,Chicagoland Skydiving Center
+24.0,29.067,-81.2837,DeLand,USA,Skydive Deland
+386.0,33.63,-117.3017,Elsinore,USA,Skydive Elsinore
+461.0,32.8067,-111.5866,Eloy,USA,Skydive Arizona
+416.0,36.5681,-114.4433,Overton,USA,Skydive Fyrosity
+83.0,47.2335,-123.1475,Shelton,USA,Skydive Kapowsin
+72.0,51.6472,7.1633,Marl,GER,Fallschirmsport Marl e.V.
+135.0,51.2472,-1.7542,Netheravon,GBR,Skydive Netheravon
+8.0,33.218,-117.3515,Oceanside,USA,GoJump Oceanside
+431.0,33.7646,-117.219,Perris,USA,Skydive Perris
+0.0,44.3643,12.2249,Ravenna,ITA,Skydive Pull Out Ravenna
+27.0,34.6656,-120.4675,Lompoc,USA,Skydive Santa Barbara
+7.0,27.8132,-80.4955,Sebastian,USA,Skydive Sebastian
+832.0,45.07929542632054,3.7620959846568214,Chazpuzac,FRA,Paraclub du Puy
+188.0,41.3997,-88.7939,Ottawa,USA,Skydive Chicago
+240.0,42.7032,-87.9589,Sturtevant,USA,Skydive Midwest
+15.0,29.3569,-95.4594,Rosharon,USA,Skydive Spaceland Houston
+27.0,28.228,-82.156,Zephyrhills,USA,Skydive City Zephyrhills
+140.0,-36.784904,145.039509,Bailieston,AUS,Skydive Nagambie
+18.0,38.2024417,-121.2691417,Lodi,USA,Skydive Lodi Parachute Center
+13.0,37.02865,15.243458,Siracusa,ITA,SkydiveSicilia Siracusa
+127.0,56.798392,37.3312258,Borki,RUS,DZ Borki
+238.0,54.789712,37.642467,Pushchino,RUS,DZ Pushchino
+156.0,46.389969,17.731702,Kaposvar,RUS,Kapos DropZone
+26.0,44.93794,38.928427,Enem,RUS,DZ Enem
+7.0,44.597435,11.653231,Molinella,ITA,Moli D Zone
+127.0,46.86286498,18.08786809,Siofok,HUN,Skydive Balaton
+50.0,54.6494302,24.06236627,Pociunai,LTU,Kaunas Skydiving Club
+1248.0,-25.663383,28.220384,Pretoria,RSA,Skydive Pretoria
+144.0,55.091244,38.918871,Kolomna,RUS,Aerograd Kolomna
+2.0,42.25945116,3.10997844,Empuriabrava,ESP,Skydive Empuriabrava
+40.0,53.24922509,50.04617929,Samara,RUS,Sky Roads Samara
+60.0,58.98742257,24.72462416,Kuusiku,EST,Skydive Estonia
+170.0,-31.82505824,116.7982829,York,AUS,Skydive York
+331.0,50.52436163,13.68278503,Most,CZE,
+466.0,49.719174,14.097512,Pribram,CZE,
+214.0,49.4478303,17.13403702,Prostejov,CZE,JUMP-TANDEM s.r.o.
+555.0,49.42058439,15.63575506,Jihlava,CZE,
+190.0,39.5325855,-89.3307069,Taylorville,USA,Mid-America Sport Parachute
+20.0,56.31325799,10.6151104,Aarhus,DEN,
+93.0,35.02100849,-79.18919563,Raeford,USA,Skydive Paraclete XP
+1.0,53.11766712,4.82857704,Texel,NED,Paracentrum Texel
+5.0,52.24088496,6.04436338,Teuge,NED,National Paracentrum Teuge
+267.0,50.00604103,15.17419517,Kolin,CZE,
+40.0,47.08796908,39.41306591,Azov,RUS,
+160.0,47.06611354,29.09283757,Vaduleni,MDA,
+149.0,32.63484506,-116.8917874,San Diego,USA,Skydive San Diego
+19.0,37.8350433,-121.6329646,Byron,USA,Bay Area Skydiving
+16.0,43.22684599,13.74195457,Fermo,ITA,
+157.0,24.88522721,55.54800689,Dubai Desert,UAE,Skydive Dubai Desert
+0.0,25.09082159,55.13685107,Dubai Palm,UAE,Skydive Dubai Palm
+195.0,-33.34663973,18.6969173,Cape Town,RSA,
+195.0,55.66244577,36.13871098,Vatulino,RUS,
+153.0,61.14644025,25.69403887,Vesivehmaa,FIN,
+254.0,50.270693,18.67427454,Gliwice,POL,
+103.0,60.89762139,26.92609549,Utti,FIN,Skydive Finland
+1317.0,40.61318686,-112.3481226,Tooele,USA,Skydive Utah
+90.0,55.85087572,13.32844377,Eslov,SWE,
+127.0,54.27608164,40.81944466,Shilovo,RUS,DZ Krutitcy
+32.0,60.28506246,17.42562532,Tierp,SWE,Stockholm Fallskärmsklubb
+6.0,49.09533273,-122.3131299,Abbotsford,CAN,
+96.0,43.37139838,-70.92569053,Lebanon,USA,Skydive New England
+120.0,51.58022318,8.21502686,Soest,GER,Skydive Soest
+512.0,48.23524297,10.13660431,Illertissen ,GER,
+739.0,47.83980781,10.86618125,Altenstadt,GER,
+140.0,29.76916902,-97.77274668,San Marcos,USA,Skydive Spaceland San Marcos
+132.0,38.19478125,-90.38583577,Festus,USA,Fly Free Skydiving
+628.0,49.46677838,20.04737735,Nowy Targ,POL,Nowy Targ Skydive
+91.0,60.63985851,6.50203407,Voss,NOR,Skydive Voss
+16.0,43.82527776,13.03186655,Fano,ITA,Skydive Fano
+199.0,45.65325073,4.91643548,Lyon,FRA,
+195.0,-33.81211406,19.90240395,Robertson,RSA,Skydive Robertson
+22.0,45.63220146,-0.9768793,Royan,FRA,
+1.0,54.710181,18.64605188,Jastarnia,POL,
+184.0,46.630755,16.178322,Murska Sobota,SLO,
+45.0,37.29575614,-6.16133451,Seville,ESP,
+49.0,45.16766289,10.0071609,Cremona,ITA,
+305.0,44.83440972,7.36347914,Garzigliana,ITA,
 41.6,36.68199744,-121.7685342,Marina,USA,Skydive Monterey Bay
-186,-34.22358828,150.6685424,Picton,AUS,
-92,-27.07007224,152.3824686,Toogoolawah,AUS,Skydive Ramblers
-68,13.14059043,101.0450149,Pattaya,THA,Thai Sky Adventures
-249,56.64716137,61.3602519,Loginovo,RUS,
-257,43.42770425,-0.28737724,Lasclaveries,FRA,
-240,46.46097203,11.32898569,Bolzano,ITA,
-45,43.996807,4.757149,Pujaut,FRA,
-290,50.15131071,4.38751459,Cerfontaine,BEL,
-470,50.47993695,5.91242552,Spa,BEL,Skydive Spa
-118,56.12712436,43.54512691,Bogorodsk,RUS,
-165,56.27125223,38.92295122,Slobodka,RUS,
-653,-34.80625409,149.7339106,Brisbane Grove,AUS,
-195,54.25086303,26.86723709,Khozhevo,RUS,
-9,-38.29661407,144.3638814,Torquay,AUS,Australian Skydive
-125,45.31080338,8.42298925,Vercelli,ITA,
-76,46.76289872,30.79006433,Kremidovka,RUS,
-186,43.4980558,23.30517769,Erden,BUL,
-60,-12.3923752,-76.75812721,San Bartolo,PER,
-154,61.77660621,22.7153331,Jamijarvi,FIN,
-46,44.69952398,10.66891551,Reggio Emilia,ITA,BFU
-399,49.38834422,10.21812201,Rothenburg ob der Tauber,GER,Fallschirmsportspringerclub Oberhausen e.V.
-1,39.99677492,0.02539515,Castellon,ESP,
-30,38.584837,-121.853758,Davis,USA,SkyDance SkyDiving
-5,-34.10285902,24.8815012,Jeffreys Bay,RSA,
-157,51.997158,6.845243,Stadtlohn,GER,
-212,47.901239,7.622785,Eschbach,GER,Skyhigh e.V. – Fallschirmsport Eschbach
-214,-7.91647034,110.5657142,Gading,INA,
-91,-43.90432806,171.8039095,Ashburton,NZL,
-155,53.33663265,34.23449278,Bryansk,RUS,
-71,44.9352382,20.44374347,Padinska Skela,SRB,
-161,43.86637658,21.48231089,Davidovac,SRB,
-10,59.29872455,10.36903381,Sem,NOR,
-140,54.76464192,-1.38691127,Durham,GBR,
-9,53.5003321,-0.52205443,Hibaldstow,GBR,Skydive Hibaldstow
-71,57.60180137,64.36770558,Turinskaya Sloboda,RUS,
-169,42.5667833,-72.28667021,Orange,USA,Skydive Orange
-577,49.06426607,11.20835334,Thalmaessing,GER,
-832,45.07689403,3.76042753,Chaspuzac,FRA,
-185,50.00461536,30.19778967,Ksaverivka,UKR,
-124,62.55523553,23.57099533,Alavus,FIN,
-336,44.96450472,-92.39083797,Baldwin,USA,Skydive Twin Cities
-295,34.26740468,-86.85919762,Vinemont,USA,Skydive Alabama
-145,29.7280624,-97.6579535,Luling,USA,Skydive Lone Star
-705,40.44862897,-99.33970928,Holdrege,USA,Skydive Atlas
-599,44.45565949,6.03594124,Tallard,FRA,
-207,42.75950473,-82.9423812,Ray,USA,Midwest Freefall
-14,61.46263073,21.80530787,Pori,FIN,Satakunnan Laskuvarjourheilijat ry
-30,-35.21328493,-59.13340151,Lobos,ARG,
-26,-33.05165003,-60.60109019,Rosario,ARG,Skydive Rosario
-130,-32.65829576,-62.70084679,Bell Ville,ARG,
-241,33.44915891,-96.37770295,Whitewright,USA,Skydive Spaceland Dallas
-35,53.3634731,11.6067338,Neustadt-Glewe,GER,Skydiving Club Mecklenburg e.V.
-5,12.710747,101.628877,Rayong,THA,
-89,-32.81409475,-61.3676548,Santa Fe,ARG,
-59,-22.65932889,14.5646739,Swakopmund,NAM,
-85,-33.57674993,18.91567826,Paarl,RSA,
-260,-39.29121996,-71.91870332,Pucon,CHI,
-1224,18.70198969,-98.89203787,Morelos,MEX,
-295,49.87389553,3.03537206,Monchy-Lagache,FRA,
-5,54.69961,11.437447,Rodby,DEN,Faldskaermsklubben.dk
-430,47.181646,7.417192,Grenchen,SUI,Skydive Grenchen
-198,39.5318056,-84.3964444,Middletown,USA,Start Skydiving
-297,34.0186944,-85.1464722,Cedartown,USA,Skydive Georgia
-198,46.165263,8.877822,Locarno,SUI,
-723,46.614984,7.6790313,Reichenbach,SUI,Skydive Switzerland
-358,40.9006164,-80.5553478,Petersburg,USA,Skydive Rick's
-145,48.492675,35.626109,Maiske,UKR,DZ Maiskoe
-195,34.790534,-81.195579,Chester,USA,Skydive Carolina
-431,46.328833,13.548833,Bovec,SLO,Aeroklub Bovec
-6,45.68732,12.70402,San Stino di Livenza,ITA,Skydive Venice
-87,45.473056,10.926944,Verona,ITA,Skydive Verona
-102,45.6755,11.496333,Thiene,ITA,Skydive Thiene
-244,50.8621683,-3.2355471,Honiton Devon,GBR,Skydive South West
-1541,40.1643889,-105.1636389,Longmont,USA,Mile-Hi Skydiving Center
-132,39.400471,9.139151,Serdiana,ITA,Skydive Sardegna
-262,33.976348,-85.168797,Rockmart,USA,Skydive Spaceland Atlanta
-64,45.5213889,-75.5641667,Gatineau,CAN,Parachute GO Skydive
-55,45.285793,-73.007171,Farnham,CAN,Nouvel Air Skydiving
-51,56.1847,9.04445,Herning,DEN,Dropzone Denmark
-688,46.593343,7.094463,Gruyeres,SUI,EPCO - Gruyere
-653,-34.809077,149.726989,Goulburn,AUS,Adrenalin Skydive
-486,47.226164,8.078353,Triengen,SUI,PARA-SPORT-CLUB Triengen
-15,-30.303543,115.055035,Jurien Bay,AUS,Skydive Jurien Bay
-73,53.249674,-7.123328,Clonbullogue,IRL,Irish Parachute Club
-506,47.508978,9.262669,Sitterdorf,SUI,Fallschirmgruppe Sittertal
-3,55.852741,12.072545,Frederikssund,DEN,Nordsjællands Faldskærmsklub
-675,54.141688,-113.740138,Westlock,CAN,Edmonton Skydive
-737,53.624697,-114.167311,Onoway,CAN,Eden North Parachute Schools
-34,-32.599701,151.339996,Elderslie,AUS,Skydive Elderslie - Newcastle Sport Parachute Club
-168,45.7803,-74.061897,Saint-Jerome,CAN,Parachutisme Adrenaline Saint-Jerome
-11,37.7313264,-121.3355889,Tracy,USA,Skydive California
-7,43.784226,10.603388,Capannori,ITA,Skydive Lucca
-100,58.039167,12.785833,Vargarda,SWE,Fallskaermsklubben Cirrus Goeteborg
-185,50.004393,30.19691,Pinchuky,UKR,Dropzone 5 Ocean
-119,55.720724,53.060472,Menzelinsk,RUS,Aeroclub Menzelinsk
-148,46.110833,-71.931667,Victoriaville,CAN,Parachute Victoriaville
-61,46.352778,-72.679444,Trois-Rivieres,CAN,Parachutisme Adrenaline Trois-Rivieres
-156,48.369301,7.82772,Lahr,GER,Skydive Black Forest Lahr
-99,58.456402,13.9727,Skovde,SWE,Skovde Flygplats
-2,37.149552,-8.584431,Alvor,POR,Skydive Algarve
-559,50.676388,8.169444,Breitscheid,GER,Skydive Westerwald
-4,21.5794736,-158.1972814,Waialua,USA,Pacific Skydiving Center
-4,21.5794736,-158.1972814,Waialua,USA,Skydive Hawaii
-114,52.3192,18.166998,Kazimierz Biskupi,POL,Sky Camp Drop Zone
-6,26.7351667,-81.0510556,Clewiston,USA,Skydive Spaceland Florida
-418,41.1460278,-80.16775,Mercer,USA,Skydive Pennsylvania
-272,38.2897778,-94.3401389,Butler,USA,Skydive Kansas City
-36,30.487157,-85.113785,Altha,USA,Skydive Panama City
-15,29.6583825,-81.6895031,Palatka,USA,Skydive Palatka
-330,35.3800295,-86.2463536,Tullahoma,USA,Skydive Tullahoma
-1524,-26.369198,27.349391,Carletonville,RSA,Johannesburg Skydiving Club
-37,52.89593,-0.90101,Langar,GBR,Skydive Langar
-4,53.9658,-2.83126878,Cockerham,GBR,Black Knights Parachute Centre
-154,52.028717,-1.207157,Brackley,GBR,Hinton Skydiving Centre
-412,47.384998,9.7,Hohenems,AUT,Skydive Hohenems
-27,53.994446,9.578611,Hohenlockstedt,GER,YUU-Skydive Fallschirmsport e.V.
-141,50.667,29.915001,Borodyanka,UKR,Aerodrom Borodyanka
-1128,-25.6443,27.271099,Rustenburg,RSA,SkyDive Rustenburg
-183,42.877499,-79.352798,Wainfleet,CAN,Skydive Burnaby
-139,48.554401,7.77806,Strasbourg,FRA,Regional School Skydiving Center of Alsace
-630,47.270566,9.110623,Ebnat-Kappel,SUI,
-162,-34.158298,22.058599,Mossel Bay,RSA,Skydive Mossel Bay
-654,47.189999,8.20472,Neudorf,SUI,Paraclub Beromünster - Skydive Luzern
-213,54.758114,85.112972,Zhuravlevo,RUS,Aerodrom Tanay
-42,52.793331,12.760278,Fehrbellin,GER,TAKE OFF Fallschirmsport
-134,47.723301,-2.71856,Vannes,FRA,
-251,38.354669,-93.67516,Clinton,USA,Glidersports Skydiving
-116,59.397499,11.3469,Rakkestad,NOR,Nimbus fallskjermklubb
-39,52.5855,8.340667,Diepholz,GER,
-21,36.6828884,-76.5996232,Suffolk,USA,Skydive Suffolk
-91,38.455993,23.134503,Akrefnia,GRE,Skydive Athens
-85,51.0154,5.52647,Zwartberg,BEL,PCV - Dropzone Zwartberg
-4,-37.671902,176.195999,Tauranga,NZL,Skydive Tauranga
-278,44.351398,1.47528,Cieurac,FRA,Centre Ecole de Parachutisme de Cahors
-262,33.976176,-85.168775,Rockmart_duplicate,USA,Skydive Spaceland Atlanta_duplicate
-18,-21.3209,55.424999,Pierrefonds,FRA,Para Club de Bourbon
-509,32.400002,-6.33333,Beni Mellal,MAR,Parachute Air Club Maroc
-625,-23.298056,-47.691944,Boituva,BRA,Parachuting Sky Company
-59,59.835019,31.480613,Putilovo,RUS,DZ Putilovo
-494,61.257401,11.6689,Rena,NOR,Oslo Fallskjermklubb
-4,-35.8978,150.143997,Moruya,AUS,Skydive Oz
-7,42.494951,11.239309,Orbetello,ITA,Skydive Costa d'Argento
-312,48.446899,15.635,Krems,AUT,Jump Club Krems
-410,48.518055,13.345833,Fuerstenzell,GER,Fallschirmsport-Club Passau e.V.
-81,47.144402,20.1978,Szolnok,HUN,
-30,50.999199,5.06556,Schaffen,BEL,Skydive Flanders - Schaffen
-14,-17.559401,146.011993,Mundoo,AUS,Tandem Cairns
-733,39.9375,-3.50333,Ocana,ESP,Skydive Madrid
-396,49.418301,13.3219,Klatovy,CZE,Skydive Pink Klatovy
-20,50.852798,3.14731,Wevelgem,BEL,Skydive Flanders
-50,53.006699,13.205,Gransee,GER,FSG Fallschirmsportgemeinschaft
-248,43.455898,11.847,Arezzo,ITA,Paracadutismo Arezzo
-90,49.8685,3.02958,Monchy-Lagache,FRA,Skydiving-France
-285,47.84,16.221701,Wiener Neustadt,AUT,Fallschirmspringen Para Club Wr. Neustadt
-433,46.761902,6.61333,Yverdon-les-Bains,SUI,Para-Club Valais
-104,41.66676,-74.14959,Gardiner,USA,Skydive The Ranch
-560,46.756401,7.60056,Thun,SUI,Sprungplatz - Skydive Grenchen in Thun
-400,46.258301,6.98639,Bex,SUI,GPS-Bex
-54,42.696194,-71.550056,Pepperell,USA,Skydive Pepperell
-150,49.031666,7.99,Schweighofen,GER,FSC Südpfalz
-277,51.408333,9.3775,Calden,GER,Aero Parachute sport GmbH
-3,51.306099,4.38722,Hoevenen,BEL,Skydive Antwerp
-472,32.6608472,-111.6815306,Sawtooth,USA,Sawtooth
-1317,40.612395,-112.350855,Erda,USA,Skydive Utah
-292,48.5928,6.24111,Azelot,FRA,Parachutisme Nancy Lorraine
-315,33.4204167,-112.6861808,Buckeye,USA,Skydive Buckeye
-3,-28.594696,153.551102,Tyagarah,AUS,Skydive Byron Bay
-5,12.67328127,", 101.54867260682072",Rayong,THA,Dropzone Thailand
-114,52.573889,20.871667,Warszawa,POL,Skydive Warszawa
-581,48.029090,9.504839,Bad Saulgau,DEU,Skydive Saulgau
-9,59.58200212744969,16.50168799813618,Västerås,SWE,Fallskärmsklubben Aros
-20,55.923415066618475,14.095702226806454,Everöd,SWE,Skånes Fallskärmsklubb
-3,34.7337586,-76.6603547,Beauford NC,USA,Crystal Coast Skydiving
-24,52.43500736999359,1.6178792409503804,Suffolk,GBR,UK Parachuting Beccles
-368,40.89781123032923,-82.25702384492351,Ashland OH,USA,AerOhio
-305,41.35216465499883,(-81.09909843384227,Cleveland OH,USA,Cleveland Skydiving Center
-200,31.285284,34.7194287,Sde Teman,ISR,Skykef
+186.0,-34.22358828,150.6685424,Picton,AUS,
+92.0,-27.07007224,152.3824686,Toogoolawah,AUS,Skydive Ramblers
+68.0,13.14059043,101.0450149,Pattaya,THA,Thai Sky Adventures
+249.0,56.64716137,61.3602519,Loginovo,RUS,
+257.0,43.42770425,-0.28737724,Lasclaveries,FRA,
+240.0,46.46097203,11.32898569,Bolzano,ITA,
+45.0,43.996807,4.757149,Pujaut,FRA,
+290.0,50.15131071,4.38751459,Cerfontaine,BEL,
+470.0,50.47993695,5.91242552,Spa,BEL,Skydive Spa
+118.0,56.12712436,43.54512691,Bogorodsk,RUS,
+165.0,56.27125223,38.92295122,Slobodka,RUS,
+195.0,54.25086303,26.86723709,Khozhevo,RUS,
+9.0,-38.29661407,144.3638814,Torquay,AUS,Australian Skydive
+125.0,45.31080338,8.42298925,Vercelli,ITA,
+76.0,46.76289872,30.79006433,Kremidovka,RUS,
+186.0,43.4980558,23.30517769,Erden,BUL,
+60.0,-12.3923752,-76.75812721,San Bartolo,PER,
+154.0,61.77660621,22.7153331,Jamijarvi,FIN,
+46.0,44.69952398,10.66891551,Reggio Emilia,ITA,BFU
+399.0,49.38834422,10.21812201,Rothenburg ob der Tauber,GER,Fallschirmsportspringerclub Oberhausen e.V.
+1.0,39.99677492,0.02539515,Castellon,ESP,
+30.0,38.584837,-121.853758,Davis,USA,SkyDance SkyDiving
+5.0,-34.10285902,24.8815012,Jeffreys Bay,RSA,
+157.0,51.997158,6.845243,Stadtlohn,GER,
+212.0,47.901239,7.622785,Eschbach,GER,Skyhigh e.V. – Fallschirmsport Eschbach
+214.0,-7.91647034,110.5657142,Gading,INA,
+91.0,-43.90432806,171.8039095,Ashburton,NZL,
+155.0,53.33663265,34.23449278,Bryansk,RUS,
+71.0,44.9352382,20.44374347,Padinska Skela,SRB,
+161.0,43.86637658,21.48231089,Davidovac,SRB,
+10.0,59.29872455,10.36903381,Sem,NOR,
+140.0,54.76464192,-1.38691127,Durham,GBR,
+9.0,53.5003321,-0.52205443,Hibaldstow,GBR,Skydive Hibaldstow
+71.0,57.60180137,64.36770558,Turinskaya Sloboda,RUS,
+169.0,42.5667833,-72.28667021,Orange,USA,Skydive Orange
+577.0,49.06426607,11.20835334,Thalmaessing,GER,
+124.0,62.55523553,23.57099533,Alavus,FIN,
+336.0,44.96450472,-92.39083797,Baldwin,USA,Skydive Twin Cities
+295.0,34.26740468,-86.85919762,Vinemont,USA,Skydive Alabama
+145.0,29.7280624,-97.6579535,Luling,USA,Skydive Lone Star
+705.0,40.44862897,-99.33970928,Holdrege,USA,Skydive Atlas
+599.0,44.45565949,6.03594124,Tallard,FRA,
+207.0,42.75950473,-82.9423812,Ray,USA,Midwest Freefall
+14.0,61.46263073,21.80530787,Pori,FIN,Satakunnan Laskuvarjourheilijat ry
+30.0,-35.21328493,-59.13340151,Lobos,ARG,
+26.0,-33.05165003,-60.60109019,Rosario,ARG,Skydive Rosario
+130.0,-32.65829576,-62.70084679,Bell Ville,ARG,
+241.0,33.44915891,-96.37770295,Whitewright,USA,Skydive Spaceland Dallas
+35.0,53.3634731,11.6067338,Neustadt-Glewe,GER,Skydiving Club Mecklenburg e.V.
+5.0,12.710747,101.628877,Rayong,THA,
+89.0,-32.81409475,-61.3676548,Santa Fe,ARG,
+59.0,-22.65932889,14.5646739,Swakopmund,NAM,
+85.0,-33.57674993,18.91567826,Paarl,RSA,
+260.0,-39.29121996,-71.91870332,Pucon,CHI,
+1224.0,18.70198969,-98.89203787,Morelos,MEX,
+5.0,54.69961,11.437447,Rodby,DEN,Faldskaermsklubben.dk
+430.0,47.181646,7.417192,Grenchen,SUI,Skydive Grenchen
+198.0,39.5318056,-84.3964444,Middletown,USA,Start Skydiving
+297.0,34.0186944,-85.1464722,Cedartown,USA,Skydive Georgia
+198.0,46.165263,8.877822,Locarno,SUI,
+723.0,46.614984,7.6790313,Reichenbach,SUI,Skydive Switzerland
+358.0,40.9006164,-80.5553478,Petersburg,USA,Skydive Rick's
+145.0,48.492675,35.626109,Maiske,UKR,DZ Maiskoe
+195.0,34.790534,-81.195579,Chester,USA,Skydive Carolina
+431.0,46.328833,13.548833,Bovec,SLO,Aeroklub Bovec
+6.0,45.68732,12.70402,San Stino di Livenza,ITA,Skydive Venice
+87.0,45.473056,10.926944,Verona,ITA,Skydive Verona
+102.0,45.6755,11.496333,Thiene,ITA,Skydive Thiene
+244.0,50.8621683,-3.2355471,Honiton Devon,GBR,Skydive South West
+1541.0,40.1643889,-105.1636389,Longmont,USA,Mile-Hi Skydiving Center
+132.0,39.400471,9.139151,Serdiana,ITA,Skydive Sardegna
+262.0,33.976348,-85.168797,Rockmart,USA,Skydive Spaceland Atlanta
+64.0,45.5213889,-75.5641667,Gatineau,CAN,Parachute GO Skydive
+55.0,45.285793,-73.007171,Farnham,CAN,Nouvel Air Skydiving
+51.0,56.1847,9.04445,Herning,DEN,Dropzone Denmark
+688.0,46.593343,7.094463,Gruyeres,SUI,EPCO - Gruyere
+653.0,-34.809077,149.726989,Goulburn,AUS,Adrenalin Skydive
+486.0,47.226164,8.078353,Triengen,SUI,PARA-SPORT-CLUB Triengen
+15.0,-30.303543,115.055035,Jurien Bay,AUS,Skydive Jurien Bay
+73.0,53.249674,-7.123328,Clonbullogue,IRL,Irish Parachute Club
+506.0,47.508978,9.262669,Sitterdorf,SUI,Fallschirmgruppe Sittertal
+3.0,55.852741,12.072545,Frederikssund,DEN,Nordsjællands Faldskærmsklub
+675.0,54.141688,-113.740138,Westlock,CAN,Edmonton Skydive
+737.0,53.624697,-114.167311,Onoway,CAN,Eden North Parachute Schools
+34.0,-32.599701,151.339996,Elderslie,AUS,Skydive Elderslie - Newcastle Sport Parachute Club
+168.0,45.7803,-74.061897,Saint-Jerome,CAN,Parachutisme Adrenaline Saint-Jerome
+11.0,37.7313264,-121.3355889,Tracy,USA,Skydive California
+7.0,43.784226,10.603388,Capannori,ITA,Skydive Lucca
+100.0,58.039167,12.785833,Vargarda,SWE,Fallskaermsklubben Cirrus Goeteborg
+185.0,50.004393,30.19691,Pinchuky,UKR,Dropzone 5 Ocean
+119.0,55.720724,53.060472,Menzelinsk,RUS,Aeroclub Menzelinsk
+148.0,46.110833,-71.931667,Victoriaville,CAN,Parachute Victoriaville
+61.0,46.352778,-72.679444,Trois-Rivieres,CAN,Parachutisme Adrenaline Trois-Rivieres
+156.0,48.369301,7.82772,Lahr,GER,Skydive Black Forest Lahr
+99.0,58.456402,13.9727,Skovde,SWE,Skovde Flygplats
+2.0,37.149552,-8.584431,Alvor,POR,Skydive Algarve
+559.0,50.676388,8.169444,Breitscheid,GER,Skydive Westerwald
+4.0,21.5794736,-158.1972814,Waialua,USA,Pacific Skydiving Center
+4.0,21.5794736,-158.1972814,Waialua,USA,Skydive Hawaii
+114.0,52.3192,18.166998,Kazimierz Biskupi,POL,Sky Camp Drop Zone
+6.0,26.7351667,-81.0510556,Clewiston,USA,Skydive Spaceland Florida
+418.0,41.1460278,-80.16775,Mercer,USA,Skydive Pennsylvania
+272.0,38.2897778,-94.3401389,Butler,USA,Skydive Kansas City
+36.0,30.487157,-85.113785,Altha,USA,Skydive Panama City
+15.0,29.6583825,-81.6895031,Palatka,USA,Skydive Palatka
+330.0,35.3800295,-86.2463536,Tullahoma,USA,Skydive Tullahoma
+1524.0,-26.369198,27.349391,Carletonville,RSA,Johannesburg Skydiving Club
+37.0,52.89593,-0.90101,Langar,GBR,Skydive Langar
+4.0,53.9658,-2.83126878,Cockerham,GBR,Black Knights Parachute Centre
+154.0,52.028717,-1.207157,Brackley,GBR,Hinton Skydiving Centre
+412.0,47.384998,9.7,Hohenems,AUT,Skydive Hohenems
+27.0,53.994446,9.578611,Hohenlockstedt,GER,YUU-Skydive Fallschirmsport e.V.
+141.0,50.667,29.915001,Borodyanka,UKR,Aerodrom Borodyanka
+1128.0,-25.6443,27.271099,Rustenburg,RSA,SkyDive Rustenburg
+183.0,42.877499,-79.352798,Wainfleet,CAN,Skydive Burnaby
+139.0,48.554401,7.77806,Strasbourg,FRA,Regional School Skydiving Center of Alsace
+630.0,47.270566,9.110623,Ebnat-Kappel,SUI,
+162.0,-34.158298,22.058599,Mossel Bay,RSA,Skydive Mossel Bay
+654.0,47.189999,8.20472,Neudorf,SUI,Paraclub Beromünster - Skydive Luzern
+213.0,54.758114,85.112972,Zhuravlevo,RUS,Aerodrom Tanay
+42.0,52.793331,12.760278,Fehrbellin,GER,TAKE OFF Fallschirmsport
+134.0,47.723301,-2.71856,Vannes,FRA,
+251.0,38.354669,-93.67516,Clinton,USA,Glidersports Skydiving
+116.0,59.397499,11.3469,Rakkestad,NOR,Nimbus fallskjermklubb
+39.0,52.5855,8.340667,Diepholz,GER,
+21.0,36.6828884,-76.5996232,Suffolk,USA,Skydive Suffolk
+91.0,38.455993,23.134503,Akrefnia,GRE,Skydive Athens
+85.0,51.0154,5.52647,Zwartberg,BEL,PCV - Dropzone Zwartberg
+4.0,-37.671902,176.195999,Tauranga,NZL,Skydive Tauranga
+278.0,44.351398,1.47528,Cieurac,FRA,Centre Ecole de Parachutisme de Cahors
+18.0,-21.3209,55.424999,Pierrefonds,FRA,Para Club de Bourbon
+509.0,32.400002,-6.33333,Beni Mellal,MAR,Parachute Air Club Maroc
+625.0,-23.298056,-47.691944,Boituva,BRA,Parachuting Sky Company
+59.0,59.835019,31.480613,Putilovo,RUS,DZ Putilovo
+494.0,61.257401,11.6689,Rena,NOR,Oslo Fallskjermklubb
+4.0,-35.8978,150.143997,Moruya,AUS,Skydive Oz
+7.0,42.494951,11.239309,Orbetello,ITA,Skydive Costa d'Argento
+312.0,48.446899,15.635,Krems,AUT,Jump Club Krems
+410.0,48.518055,13.345833,Fuerstenzell,GER,Fallschirmsport-Club Passau e.V.
+81.0,47.144402,20.1978,Szolnok,HUN,
+30.0,50.999199,5.06556,Schaffen,BEL,Skydive Flanders - Schaffen
+14.0,-17.559401,146.011993,Mundoo,AUS,Tandem Cairns
+733.0,39.9375,-3.50333,Ocana,ESP,Skydive Madrid
+396.0,49.418301,13.3219,Klatovy,CZE,Skydive Pink Klatovy
+20.0,50.852798,3.14731,Wevelgem,BEL,Skydive Flanders
+50.0,53.006699,13.205,Gransee,GER,FSG Fallschirmsportgemeinschaft
+248.0,43.455898,11.847,Arezzo,ITA,Paracadutismo Arezzo
+90.0,49.8685,3.02958,Monchy-Lagache,FRA,Skydiving-France
+285.0,47.84,16.221701,Wiener Neustadt,AUT,Fallschirmspringen Para Club Wr. Neustadt
+433.0,46.761902,6.61333,Yverdon-les-Bains,SUI,Para-Club Valais
+104.0,41.66676,-74.14959,Gardiner,USA,Skydive The Ranch
+560.0,46.756401,7.60056,Thun,SUI,Sprungplatz - Skydive Grenchen in Thun
+400.0,46.258301,6.98639,Bex,SUI,GPS-Bex
+54.0,42.696194,-71.550056,Pepperell,USA,Skydive Pepperell
+150.0,49.031666,7.99,Schweighofen,GER,FSC Südpfalz
+277.0,51.408333,9.3775,Calden,GER,Aero Parachute sport GmbH
+3.0,51.306099,4.38722,Hoevenen,BEL,Skydive Antwerp
+472.0,32.6608472,-111.6815306,Sawtooth,USA,Sawtooth
+292.0,48.5928,6.24111,Azelot,FRA,Parachutisme Nancy Lorraine
+315.0,33.4204167,-112.6861808,Buckeye,USA,Skydive Buckeye
+3.0,-28.594696,153.551102,Tyagarah,AUS,Skydive Byron Bay
+5.0,12.67328127,", 101.54867260682072",Rayong,THA,Dropzone Thailand
+114.0,52.573889,20.871667,Warszawa,POL,Skydive Warszawa
+581.0,48.02909,9.504839,Bad Saulgau,DEU,Skydive Saulgau
+9.0,59.58200212744969,16.50168799813618,Västerås,SWE,Fallskärmsklubben Aros
+20.0,55.923415066618475,14.095702226806454,Everöd,SWE,Skånes Fallskärmsklubb
+3.0,34.7337586,-76.6603547,Beauford NC,USA,Crystal Coast Skydiving
+24.0,52.43500736999359,1.6178792409503804,Suffolk,GBR,UK Parachuting Beccles
+368.0,40.89781123032923,-82.25702384492351,Ashland OH,USA,AerOhio
+305.0,41.35216465499883,(-81.09909843384227,Cleveland OH,USA,Cleveland Skydiving Center
+200.0,31.285284,34.7194287,Sde Teman,ISR,Skykef

--- a/resources/drop-zones-loc-elev-raw_csv-BAD.org
+++ b/resources/drop-zones-loc-elev-raw_csv-BAD.org
@@ -1,0 +1,259 @@
+elevation,lat,lon,name,country,DZ
+2,36.649092,174.934864,Parakai Auckland,NZL,Skydive Auckland
+238,41.8926,-89.0796,Rochelle,USA,Chicagoland Skydiving Center
+24,29.067,-81.2837,DeLand,USA,Skydive Deland
+386,33.63,-117.3017,Elsinore,USA,Skydive Elsinore
+461,32.8067,-111.5866,Eloy,USA,Skydive Arizona
+416,36.5681,-114.4433,Overton,USA,Skydive Fyrosity
+83,47.2335,-123.1475,Shelton,USA,Skydive Kapowsin
+72,51.6472,7.1633,Marl,GER,Fallschirmsport Marl e.V.
+135,51.2472,-1.7542,Netheravon,GBR,Skydive Netheravon
+8,33.218,-117.3515,Oceanside,USA,GoJump Oceanside
+431,33.7646,-117.219,Perris,USA,Skydive Perris
+0,44.3643,12.2249,Ravenna,ITA,Skydive Pull Out Ravenna
+27,34.6656,-120.4675,Lompoc,USA,Skydive Santa Barbara
+7,27.8132,-80.4955,Sebastian,USA,Skydive Sebastian
+832,45.07929542632054,3.7620959846568214,Chazpuzac,FRA,Paraclub du Puy
+188,41.3997,-88.7939,Ottawa,USA,Skydive Chicago
+240,42.7032,-87.9589,Sturtevant,USA,Skydive Midwest
+15,29.3569,-95.4594,Rosharon,USA,Skydive Spaceland Houston
+27,28.228,-82.156,Zephyrhills,USA,Skydive City Zephyrhills
+140,-36.784904,145.039509,Bailieston,AUS,Skydive Nagambie
+18,38.2024417,-121.2691417,Lodi,USA,Skydive Lodi Parachute Center
+13,37.02865,15.243458,Siracusa,ITA,SkydiveSicilia Siracusa
+127,56.798392,37.3312258,Borki,RUS,DZ Borki
+238,54.789712,37.642467,Pushchino,RUS,DZ Pushchino
+156,46.389969,17.731702,Kaposvar,RUS,Kapos DropZone
+26,44.93794,38.928427,Enem,RUS,DZ Enem
+7,44.597435,11.653231,Molinella,ITA,Moli D Zone
+127,46.86286498,18.08786809,Siofok,HUN,Skydive Balaton
+50,54.6494302,24.06236627,Pociunai,LTU,Kaunas Skydiving Club
+1248,-25.663383,28.220384,Pretoria,RSA,Skydive Pretoria
+144,55.091244,38.918871,Kolomna,RUS,Aerograd Kolomna
+2,42.25945116,3.10997844,Empuriabrava,ESP,Skydive Empuriabrava
+40,53.24922509,50.04617929,Samara,RUS,Sky Roads Samara
+60,58.98742257,24.72462416,Kuusiku,EST,Skydive Estonia
+170,-31.82505824,116.7982829,York,AUS,Skydive York
+331,50.52436163,13.68278503,Most,CZE,
+466,49.719174,14.097512,Pribram,CZE,
+214,49.4478303,17.13403702,Prostejov,CZE,JUMP-TANDEM s.r.o.
+555,49.42058439,15.63575506,Jihlava,CZE,
+190,39.5325855,-89.3307069,Taylorville,USA,Mid-America Sport Parachute
+20,56.31325799,10.6151104,Aarhus,DEN,
+93,35.02100849,-79.18919563,Raeford,USA,Skydive Paraclete XP
+1,53.11766712,4.82857704,Texel,NED,Paracentrum Texel
+5,52.24088496,6.04436338,Teuge,NED,National Paracentrum Teuge
+267,50.00604103,15.17419517,Kolin,CZE,
+40,47.08796908,39.41306591,Azov,RUS,
+160,47.06611354,29.09283757,Vaduleni,MDA,
+149,32.63484506,-116.8917874,San Diego,USA,Skydive San Diego
+19,37.8350433,-121.6329646,Byron,USA,Bay Area Skydiving
+16,43.22684599,13.74195457,Fermo,ITA,
+157,24.88522721,55.54800689,Dubai Desert,UAE,Skydive Dubai Desert
+0,25.09082159,55.13685107,Dubai Palm,UAE,Skydive Dubai Palm
+195,-33.34663973,18.6969173,Cape Town,RSA,
+195,55.66244577,36.13871098,Vatulino,RUS,
+153,61.14644025,25.69403887,Vesivehmaa,FIN,
+254,50.270693,18.67427454,Gliwice,POL,
+103,60.89762139,26.92609549,Utti,FIN,Skydive Finland
+1317,40.61318686,-112.3481226,Tooele,USA,Skydive Utah
+675,54.14057759,-113.7459719,Edmonton,CAN,
+90,55.85087572,13.32844377,Eslov,SWE,
+127,54.27608164,40.81944466,Shilovo,RUS,DZ Krutitcy
+32,60.28506246,17.42562532,Tierp,SWE,Stockholm Fallskärmsklubb
+6,49.09533273,-122.3131299,Abbotsford,CAN,
+96,43.37139838,-70.92569053,Lebanon,USA,Skydive New England
+120,51.58022318,8.21502686,Soest,GER,Skydive Soest
+512,48.23524297,10.13660431,Illertissen ,GER,
+739,47.83980781,10.86618125,Altenstadt,GER,
+140,29.76916902,-97.77274668,San Marcos,USA,Skydive Spaceland San Marcos
+132,38.19478125,-90.38583577,Festus,USA,Fly Free Skydiving
+628,49.46677838,20.04737735,Nowy Targ,POL,Nowy Targ Skydive
+91,60.63985851,6.50203407,Voss,NOR,Skydive Voss
+16,43.82527776,13.03186655,Fano,ITA,Skydive Fano
+199,45.65325073,4.91643548,Lyon,FRA,
+195,-33.81211406,19.90240395,Robertson,RSA,Skydive Robertson
+22,45.63220146,-0.9768793,Royan,FRA,
+1,54.710181,18.64605188,Jastarnia,POL,
+184,46.630755,16.178322,Murska Sobota,SLO,
+45,37.29575614,-6.16133451,Seville,ESP,
+49,45.16766289,10.0071609,Cremona,ITA,
+305,44.83440972,7.36347914,Garzigliana,ITA,
+41.6,36.68199744,-121.7685342,Marina,USA,Skydive Monterey Bay
+186,-34.22358828,150.6685424,Picton,AUS,
+92,-27.07007224,152.3824686,Toogoolawah,AUS,Skydive Ramblers
+68,13.14059043,101.0450149,Pattaya,THA,Thai Sky Adventures
+249,56.64716137,61.3602519,Loginovo,RUS,
+257,43.42770425,-0.28737724,Lasclaveries,FRA,
+240,46.46097203,11.32898569,Bolzano,ITA,
+45,43.996807,4.757149,Pujaut,FRA,
+290,50.15131071,4.38751459,Cerfontaine,BEL,
+470,50.47993695,5.91242552,Spa,BEL,Skydive Spa
+118,56.12712436,43.54512691,Bogorodsk,RUS,
+165,56.27125223,38.92295122,Slobodka,RUS,
+653,-34.80625409,149.7339106,Brisbane Grove,AUS,
+195,54.25086303,26.86723709,Khozhevo,RUS,
+9,-38.29661407,144.3638814,Torquay,AUS,Australian Skydive
+125,45.31080338,8.42298925,Vercelli,ITA,
+76,46.76289872,30.79006433,Kremidovka,RUS,
+186,43.4980558,23.30517769,Erden,BUL,
+60,-12.3923752,-76.75812721,San Bartolo,PER,
+154,61.77660621,22.7153331,Jamijarvi,FIN,
+46,44.69952398,10.66891551,Reggio Emilia,ITA,BFU
+399,49.38834422,10.21812201,Rothenburg ob der Tauber,GER,Fallschirmsportspringerclub Oberhausen e.V.
+1,39.99677492,0.02539515,Castellon,ESP,
+30,38.584837,-121.853758,Davis,USA,SkyDance SkyDiving
+5,-34.10285902,24.8815012,Jeffreys Bay,RSA,
+157,51.997158,6.845243,Stadtlohn,GER,
+212,47.901239,7.622785,Eschbach,GER,Skyhigh e.V. – Fallschirmsport Eschbach
+214,-7.91647034,110.5657142,Gading,INA,
+91,-43.90432806,171.8039095,Ashburton,NZL,
+155,53.33663265,34.23449278,Bryansk,RUS,
+71,44.9352382,20.44374347,Padinska Skela,SRB,
+161,43.86637658,21.48231089,Davidovac,SRB,
+10,59.29872455,10.36903381,Sem,NOR,
+140,54.76464192,-1.38691127,Durham,GBR,
+9,53.5003321,-0.52205443,Hibaldstow,GBR,Skydive Hibaldstow
+71,57.60180137,64.36770558,Turinskaya Sloboda,RUS,
+169,42.5667833,-72.28667021,Orange,USA,Skydive Orange
+577,49.06426607,11.20835334,Thalmaessing,GER,
+832,45.07689403,3.76042753,Chaspuzac,FRA,
+185,50.00461536,30.19778967,Ksaverivka,UKR,
+124,62.55523553,23.57099533,Alavus,FIN,
+336,44.96450472,-92.39083797,Baldwin,USA,Skydive Twin Cities
+295,34.26740468,-86.85919762,Vinemont,USA,Skydive Alabama
+145,29.7280624,-97.6579535,Luling,USA,Skydive Lone Star
+705,40.44862897,-99.33970928,Holdrege,USA,Skydive Atlas
+599,44.45565949,6.03594124,Tallard,FRA,
+207,42.75950473,-82.9423812,Ray,USA,Midwest Freefall
+14,61.46263073,21.80530787,Pori,FIN,Satakunnan Laskuvarjourheilijat ry
+30,-35.21328493,-59.13340151,Lobos,ARG,
+26,-33.05165003,-60.60109019,Rosario,ARG,Skydive Rosario
+130,-32.65829576,-62.70084679,Bell Ville,ARG,
+241,33.44915891,-96.37770295,Whitewright,USA,Skydive Spaceland Dallas
+35,53.3634731,11.6067338,Neustadt-Glewe,GER,Skydiving Club Mecklenburg e.V.
+5,12.710747,101.628877,Rayong,THA,
+89,-32.81409475,-61.3676548,Santa Fe,ARG,
+59,-22.65932889,14.5646739,Swakopmund,NAM,
+85,-33.57674993,18.91567826,Paarl,RSA,
+260,-39.29121996,-71.91870332,Pucon,CHI,
+1224,18.70198969,-98.89203787,Morelos,MEX,
+295,49.87389553,3.03537206,Monchy-Lagache,FRA,
+5,54.69961,11.437447,Rodby,DEN,Faldskaermsklubben.dk
+430,47.181646,7.417192,Grenchen,SUI,Skydive Grenchen
+198,39.5318056,-84.3964444,Middletown,USA,Start Skydiving
+297,34.0186944,-85.1464722,Cedartown,USA,Skydive Georgia
+198,46.165263,8.877822,Locarno,SUI,
+723,46.614984,7.6790313,Reichenbach,SUI,Skydive Switzerland
+358,40.9006164,-80.5553478,Petersburg,USA,Skydive Rick's
+145,48.492675,35.626109,Maiske,UKR,DZ Maiskoe
+195,34.790534,-81.195579,Chester,USA,Skydive Carolina
+431,46.328833,13.548833,Bovec,SLO,Aeroklub Bovec
+6,45.68732,12.70402,San Stino di Livenza,ITA,Skydive Venice
+87,45.473056,10.926944,Verona,ITA,Skydive Verona
+102,45.6755,11.496333,Thiene,ITA,Skydive Thiene
+244,50.8621683,-3.2355471,Honiton Devon,GBR,Skydive South West
+1541,40.1643889,-105.1636389,Longmont,USA,Mile-Hi Skydiving Center
+132,39.400471,9.139151,Serdiana,ITA,Skydive Sardegna
+262,33.976348,-85.168797,Rockmart,USA,Skydive Spaceland Atlanta
+64,45.5213889,-75.5641667,Gatineau,CAN,Parachute GO Skydive
+55,45.285793,-73.007171,Farnham,CAN,Nouvel Air Skydiving
+51,56.1847,9.04445,Herning,DEN,Dropzone Denmark
+688,46.593343,7.094463,Gruyeres,SUI,EPCO - Gruyere
+653,-34.809077,149.726989,Goulburn,AUS,Adrenalin Skydive
+486,47.226164,8.078353,Triengen,SUI,PARA-SPORT-CLUB Triengen
+15,-30.303543,115.055035,Jurien Bay,AUS,Skydive Jurien Bay
+73,53.249674,-7.123328,Clonbullogue,IRL,Irish Parachute Club
+506,47.508978,9.262669,Sitterdorf,SUI,Fallschirmgruppe Sittertal
+3,55.852741,12.072545,Frederikssund,DEN,Nordsjællands Faldskærmsklub
+675,54.141688,-113.740138,Westlock,CAN,Edmonton Skydive
+737,53.624697,-114.167311,Onoway,CAN,Eden North Parachute Schools
+34,-32.599701,151.339996,Elderslie,AUS,Skydive Elderslie - Newcastle Sport Parachute Club
+168,45.7803,-74.061897,Saint-Jerome,CAN,Parachutisme Adrenaline Saint-Jerome
+11,37.7313264,-121.3355889,Tracy,USA,Skydive California
+7,43.784226,10.603388,Capannori,ITA,Skydive Lucca
+100,58.039167,12.785833,Vargarda,SWE,Fallskaermsklubben Cirrus Goeteborg
+185,50.004393,30.19691,Pinchuky,UKR,Dropzone 5 Ocean
+119,55.720724,53.060472,Menzelinsk,RUS,Aeroclub Menzelinsk
+148,46.110833,-71.931667,Victoriaville,CAN,Parachute Victoriaville
+61,46.352778,-72.679444,Trois-Rivieres,CAN,Parachutisme Adrenaline Trois-Rivieres
+156,48.369301,7.82772,Lahr,GER,Skydive Black Forest Lahr
+99,58.456402,13.9727,Skovde,SWE,Skovde Flygplats
+2,37.149552,-8.584431,Alvor,POR,Skydive Algarve
+559,50.676388,8.169444,Breitscheid,GER,Skydive Westerwald
+4,21.5794736,-158.1972814,Waialua,USA,Pacific Skydiving Center
+4,21.5794736,-158.1972814,Waialua,USA,Skydive Hawaii
+114,52.3192,18.166998,Kazimierz Biskupi,POL,Sky Camp Drop Zone
+6,26.7351667,-81.0510556,Clewiston,USA,Skydive Spaceland Florida
+418,41.1460278,-80.16775,Mercer,USA,Skydive Pennsylvania
+272,38.2897778,-94.3401389,Butler,USA,Skydive Kansas City
+36,30.487157,-85.113785,Altha,USA,Skydive Panama City
+15,29.6583825,-81.6895031,Palatka,USA,Skydive Palatka
+330,35.3800295,-86.2463536,Tullahoma,USA,Skydive Tullahoma
+1524,-26.369198,27.349391,Carletonville,RSA,Johannesburg Skydiving Club
+37,52.89593,-0.90101,Langar,GBR,Skydive Langar
+4,53.9658,-2.83126878,Cockerham,GBR,Black Knights Parachute Centre
+154,52.028717,-1.207157,Brackley,GBR,Hinton Skydiving Centre
+412,47.384998,9.7,Hohenems,AUT,Skydive Hohenems
+27,53.994446,9.578611,Hohenlockstedt,GER,YUU-Skydive Fallschirmsport e.V.
+141,50.667,29.915001,Borodyanka,UKR,Aerodrom Borodyanka
+1128,-25.6443,27.271099,Rustenburg,RSA,SkyDive Rustenburg
+183,42.877499,-79.352798,Wainfleet,CAN,Skydive Burnaby
+139,48.554401,7.77806,Strasbourg,FRA,Regional School Skydiving Center of Alsace
+630,47.270566,9.110623,Ebnat-Kappel,SUI,
+162,-34.158298,22.058599,Mossel Bay,RSA,Skydive Mossel Bay
+654,47.189999,8.20472,Neudorf,SUI,Paraclub Beromünster - Skydive Luzern
+213,54.758114,85.112972,Zhuravlevo,RUS,Aerodrom Tanay
+42,52.793331,12.760278,Fehrbellin,GER,TAKE OFF Fallschirmsport
+134,47.723301,-2.71856,Vannes,FRA,
+251,38.354669,-93.67516,Clinton,USA,Glidersports Skydiving
+116,59.397499,11.3469,Rakkestad,NOR,Nimbus fallskjermklubb
+39,52.5855,8.340667,Diepholz,GER,
+21,36.6828884,-76.5996232,Suffolk,USA,Skydive Suffolk
+91,38.455993,23.134503,Akrefnia,GRE,Skydive Athens
+85,51.0154,5.52647,Zwartberg,BEL,PCV - Dropzone Zwartberg
+4,-37.671902,176.195999,Tauranga,NZL,Skydive Tauranga
+278,44.351398,1.47528,Cieurac,FRA,Centre Ecole de Parachutisme de Cahors
+262,33.976176,-85.168775,Rockmart_duplicate,USA,Skydive Spaceland Atlanta_duplicate
+18,-21.3209,55.424999,Pierrefonds,FRA,Para Club de Bourbon
+509,32.400002,-6.33333,Beni Mellal,MAR,Parachute Air Club Maroc
+625,-23.298056,-47.691944,Boituva,BRA,Parachuting Sky Company
+59,59.835019,31.480613,Putilovo,RUS,DZ Putilovo
+494,61.257401,11.6689,Rena,NOR,Oslo Fallskjermklubb
+4,-35.8978,150.143997,Moruya,AUS,Skydive Oz
+7,42.494951,11.239309,Orbetello,ITA,Skydive Costa d'Argento
+312,48.446899,15.635,Krems,AUT,Jump Club Krems
+410,48.518055,13.345833,Fuerstenzell,GER,Fallschirmsport-Club Passau e.V.
+81,47.144402,20.1978,Szolnok,HUN,
+30,50.999199,5.06556,Schaffen,BEL,Skydive Flanders - Schaffen
+14,-17.559401,146.011993,Mundoo,AUS,Tandem Cairns
+733,39.9375,-3.50333,Ocana,ESP,Skydive Madrid
+396,49.418301,13.3219,Klatovy,CZE,Skydive Pink Klatovy
+20,50.852798,3.14731,Wevelgem,BEL,Skydive Flanders
+50,53.006699,13.205,Gransee,GER,FSG Fallschirmsportgemeinschaft
+248,43.455898,11.847,Arezzo,ITA,Paracadutismo Arezzo
+90,49.8685,3.02958,Monchy-Lagache,FRA,Skydiving-France
+285,47.84,16.221701,Wiener Neustadt,AUT,Fallschirmspringen Para Club Wr. Neustadt
+433,46.761902,6.61333,Yverdon-les-Bains,SUI,Para-Club Valais
+104,41.66676,-74.14959,Gardiner,USA,Skydive The Ranch
+560,46.756401,7.60056,Thun,SUI,Sprungplatz - Skydive Grenchen in Thun
+400,46.258301,6.98639,Bex,SUI,GPS-Bex
+54,42.696194,-71.550056,Pepperell,USA,Skydive Pepperell
+150,49.031666,7.99,Schweighofen,GER,FSC Südpfalz
+277,51.408333,9.3775,Calden,GER,Aero Parachute sport GmbH
+3,51.306099,4.38722,Hoevenen,BEL,Skydive Antwerp
+472,32.6608472,-111.6815306,Sawtooth,USA,Sawtooth
+1317,40.612395,-112.350855,Erda,USA,Skydive Utah
+292,48.5928,6.24111,Azelot,FRA,Parachutisme Nancy Lorraine
+315,33.4204167,-112.6861808,Buckeye,USA,Skydive Buckeye
+3,-28.594696,153.551102,Tyagarah,AUS,Skydive Byron Bay
+5,12.67328127,", 101.54867260682072",Rayong,THA,Dropzone Thailand
+114,52.573889,20.871667,Warszawa,POL,Skydive Warszawa
+581,48.029090,9.504839,Bad Saulgau,DEU,Skydive Saulgau
+9,59.58200212744969,16.50168799813618,Västerås,SWE,Fallskärmsklubben Aros
+20,55.923415066618475,14.095702226806454,Everöd,SWE,Skånes Fallskärmsklubb
+3,34.7337586,-76.6603547,Beauford NC,USA,Crystal Coast Skydiving
+24,52.43500736999359,1.6178792409503804,Suffolk,GBR,UK Parachuting Beccles
+368,40.89781123032923,-82.25702384492351,Ashland OH,USA,AerOhio
+305,41.35216465499883,(-81.09909843384227,Cleveland OH,USA,Cleveland Skydiving Center
+200,31.285284,34.7194287,Sde Teman,ISR,Skykef


### PR DESCRIPTION
Clean up drop-zones-loc-elev-raw.csv: remove 7 duplicate/unnamed records
258 → 251 rows.  Removed rows were either exact or near-exact duplicates
(same DZ, two records differing only in location label or sub-metre coords),
unnamed NaN entries shadowing a valid record, or a literal _duplicate-suffixed
artifact.  Retained the Hawaii pair (Pacific Skydiving Center + Skydive Hawaii)
— two distinct operations sharing Dillingham Airfield at the same elevation.

After cleanup a 5 km proximity scan returns exactly one pair (the Hawaii
airfield), confirming no ambiguous DZ remains.  Resolves https://github.com/pr3d4t0r/SSScoring/issues/154.
